### PR TITLE
callback for whether a scrollRef is visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Scroll to a position on the page
 | `easing` | `cubicInOut` | Easing function to be used when animating. Use any easing from [`svelte/easing`][svelte-easing] or a custom easing function. |
 | `onStart` | `noop` | A callback function that should be called when scrolling has started. Receives the element, offset, duration and endPosition as a parameter. |
 | `onDone` | `noop` | A callback function that should be called when scrolling has started. Receives the element, offset, duration and endPosition as a parameter. |
+| `onStateChange` | `noop` | A callback function that gets called when internal state changes. Receives the `{active}` parameter. `active` is true when the corresponding scrollRef is visible. This can be used in a navbar to show, where we currently are. |
 
 ### Override global options
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@
 Scroll to given elements with smooth animation.
 
 ## Install
+
+```bash
+npm i svelte-scrolling
+```
+
+or similar, like
+
 ```bash
 yarn add svelte-scrolling
 ```

--- a/src/actions/ScrollRef.ts
+++ b/src/actions/ScrollRef.ts
@@ -1,6 +1,29 @@
 import { get } from 'svelte/store'
-import { sanitize } from '../shared/utils'
-import { elements } from '../store'
+import { getActor, sanitize } from '../shared/utils'
+import { elements, actors } from '../store'
+
+interface HandleOpts {
+  node: HTMLElement,
+  ref: string
+}
+
+// handle with scrolling
+const handleScroll = async (event: Event, options: HandleOpts): Promise<void> => {
+  event.preventDefault()
+
+  const { ref, node } = options
+
+  const actorsList = get(actors)
+
+  const actor = getActor(actorsList, ref)
+
+  if (!actor) {
+    throw new Error(`Element reference '${ref}' not found`)
+  }
+
+  const isVisibile = node.getBoundingClientRect().top < window.innerHeight && node.getBoundingClientRect().bottom > 0
+  actor.onStateChange && actor.onStateChange({ active: isVisibile })
+}
 
 /**
  * Adds a reference to the elements that `scrollTo` should scroll
@@ -22,6 +45,8 @@ const scrollRef = ( // eslint-disable-line @typescript-eslint/explicit-module-bo
     node,
     reference: sanitize(reference)
   })
+
+  window.addEventListener('scroll', (e) => handleScroll(e, { node, ref: reference }))
 
   return {
     destroy () {

--- a/src/actions/ScrollRef.ts
+++ b/src/actions/ScrollRef.ts
@@ -51,6 +51,7 @@ const scrollRef = ( // eslint-disable-line @typescript-eslint/explicit-module-bo
   return {
     destroy () {
       elementsList.length = 0 // empty the elements list
+      window.removeEventListener('scroll', (e) => handleScroll(e, { node, ref: sanitize(reference) }))
     }
   }
 }

--- a/src/actions/ScrollRef.ts
+++ b/src/actions/ScrollRef.ts
@@ -46,7 +46,7 @@ const scrollRef = ( // eslint-disable-line @typescript-eslint/explicit-module-bo
     reference: sanitize(reference)
   })
 
-  window.addEventListener('scroll', (e) => handleScroll(e, { node, ref: reference }))
+  window.addEventListener('scroll', (e) => handleScroll(e, { node, ref: sanitize(reference) }))
 
   return {
     destroy () {

--- a/src/actions/ScrollTo.ts
+++ b/src/actions/ScrollTo.ts
@@ -1,5 +1,5 @@
 import { get } from 'svelte/store'
-import { elements } from '../store'
+import { elements, actors } from '../store'
 import { getGlobalOptions } from '../internal/globalOptions'
 import type { ScrollToOptions } from '../types/options'
 import { sanitize, getElement, getPosition } from '../shared/utils'
@@ -48,6 +48,7 @@ const scrollTo = ( // eslint-disable-line @typescript-eslint/explicit-module-bou
   }
 
   let opts: ScrollToOptions = {
+    // onStateChange: () => {},
     ref: '',
     ...getGlobalOptions()
   }
@@ -72,6 +73,15 @@ const scrollTo = ( // eslint-disable-line @typescript-eslint/explicit-module-bou
 
   node.addEventListener('click', event => handle(event, opts))
   node.addEventListener('touchstart', event => handle(event, opts))
+
+  if (opts.onStateChange) {
+    const actorsList = get(actors)
+    actorsList.push({
+      node,
+      reference: opts.ref,
+      onStateChange: opts.onStateChange
+    })
+  }
 
   return {
     destroy () {

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1,4 +1,4 @@
-import type { ElementReference } from '../types/reference'
+import type { ActorReference, ElementReference } from '../types/reference'
 
 export const sanitize = (hash: string): string => {
   return hash
@@ -17,6 +17,19 @@ export const getElement = (
   })
 
   return elements.length ? elements[0].node : null
+}
+
+export const getActor = (
+  actorsList: Array<ActorReference>,
+  reference: string
+): ActorReference | null => {
+  const actors = actorsList.filter(actor => {
+    const actorRef = actor.reference
+
+    return actorRef === reference
+  })
+
+  return actors.length ? actors[0] : null
 }
 
 export const getPosition = (

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,9 +2,10 @@ import { writable } from 'svelte/store'
 import { cubicInOut } from 'svelte/easing'
 import { noop } from 'svelte/internal'
 import type { GlobalOptions } from '../types/options'
-import type { ElementReference } from '../types/reference'
+import type { ElementReference, ActorReference } from '../types/reference'
 
 export const elements = writable<Array<ElementReference>>([])
+export const actors = writable<Array<ActorReference>>([])
 export const globalOptions = writable<GlobalOptions>({
   offset: 0,
   duration: 500,

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -20,6 +20,14 @@ export interface SmoothOptions {
   easing: (t: number) => number
 }
 
-export type ScrollToOptions = Partial<GlobalOptions> & {
+export interface StateChangeParams {
+  active: boolean,
+}
+
+export interface ActorExtras {
+  onStateChange?: (params: StateChangeParams) => void,
+}
+
+export type ScrollToOptions = Partial<GlobalOptions> & Partial<ActorExtras> & {
   ref: string
 }

--- a/src/types/reference.ts
+++ b/src/types/reference.ts
@@ -1,4 +1,11 @@
+import { ActorExtras } from './options'
+
 export interface ElementReference {
+  node: HTMLElement
+  reference: string
+}
+
+export interface ActorReference extends ActorExtras{
   node: HTMLElement
   reference: string
 }

--- a/src/types/reference.ts
+++ b/src/types/reference.ts
@@ -1,4 +1,4 @@
-import { ActorExtras } from './options'
+import type { ActorExtras } from './options'
 
 export interface ElementReference {
   node: HTMLElement


### PR DESCRIPTION
solves #10 

### example
```svelte
<script>
    import { scrollTo, scrollRef } from 'svelte-scrolling';
    let isCurrentlyVisible;
</script>

<button
    use:scrollTo={{
        ref: 'ref',
        onStateChange: ({ active }) => isCurrentlyVisible=active,
    }}
    class:isCurrentlyVisible
> to ref </button>
<section use:scrollRef={'ref'}><slot/></section>

<style>
    .isCurrentlyVisible{
        color: red;
    }
</style>
```