### PR TITLE
fix(warning): remove creation of source maps

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "declaration": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "sourceMap": false
   }
 }


### PR DESCRIPTION
as they were pointing to the unexisting `src` folder...

example warning from Svelte dev mode:
`Sourcemap for "[...]/node_modules/svelte-scrolling/dist/index.js" points to missing source files`