### PR TITLE
feat: use passive listeners

### DIFF
--- a/src/actions/ScrollTo.ts
+++ b/src/actions/ScrollTo.ts
@@ -70,8 +70,8 @@ const scrollTo = ( // eslint-disable-line @typescript-eslint/explicit-module-bou
     node.style.cursor = 'pointer'
   }
 
-  node.addEventListener('click', event => handle(event, opts))
-  node.addEventListener('touchstart', event => handle(event, opts))
+  node.addEventListener('click', event => handle(event, opts), { passive: true })
+  node.addEventListener('touchstart', event => handle(event, opts), { passive: true })
 
   return {
     destroy () {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "declaration": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "sourceMap": false
   }
 }


### PR DESCRIPTION
Based on Litehouse comment: Consider marking your touch and wheel event listeners as passive to improve your page's scroll performance